### PR TITLE
[IMP] Suport standard modules for a version and codium derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ODEV - VSCode Editor
 
-Configure VSCode for a database and open a repository in the editor.
+Configure VSCode or any other editor derivated from VSCodium (e.g. VSCodium) for a database and open a repository
+in the editor.
 
 ## Installation
 
@@ -11,4 +12,13 @@ Enable this plugin by running:
 
 ```bash
 odev plugin --enable odoo-odev/odev-plugin-editor-vscode
+```
+
+Using other editors with the same base (e.g. VSCodium) should work as well at the cost of setting up a symlink
+to the editor executable in your path.
+
+Antigravity example:
+
+```bash
+ln -s $(which antigravity) /usr/local/bin/code
 ```

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -22,7 +22,7 @@
 # or merged change.
 # ------------------------------------------------------------------------------
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 # --- Dependencies -------------------------------------------------------------
 # List other odev plugins from which this current plugin depends.

--- a/common/editor_vscode.py
+++ b/common/editor_vscode.py
@@ -1,15 +1,13 @@
 import json
 from pathlib import Path
-from typing import cast
 
-from odev.common import progress, string
+from odev.common import bash, progress, string
 from odev.common.console import console
 from odev.common.databases import LocalDatabase
 from odev.common.logging import logging
+from odev.common.odoobin import OdoobinProcess
 from odev.common.python import PythonEnv
-
 from odev.plugins.odev_plugin_editor_base.common.editor import Editor
-
 
 logger = logging.getLogger(__name__)
 
@@ -21,21 +19,33 @@ class VSCodeEditor(Editor):
     _display_name = "VSCode"
 
     @property
+    def display_name(self) -> str:
+        """Also handle other editors derivated from VSCodium (e.g. Antigravity)."""
+        name = bash.execute(f"{self._name} --help | head -n 1 | awk '{{print $1}}'")
+
+        if name and name.stdout.strip():
+            return name.stdout.strip().capitalize().decode()
+
+        return self._display_name
+
+    @property
     def command(self) -> str:
-        if isinstance(self.database, LocalDatabase):
-            return f"{self._name} {self.workspace_path}"
-        else:
-            return super().command
+        return f"{self._name} {self.workspace_path}"
 
     @property
     def workspace_directory(self) -> Path:
         """The path to the workspace directory."""
-        return self.path / ".vscode"
+        return (
+            self.path / ".vscode"
+            if isinstance(self.database, LocalDatabase)
+            else self.path
+        )
 
     @property
     def workspace_path(self) -> Path:
         """The path to the workspace file."""
-        return self.workspace_directory / f"{self.database.name}.code-workspace"
+        name = self.database.name if isinstance(self.database, LocalDatabase) else str(self.version)
+        return self.workspace_directory / f"{name}.code-workspace"
 
     @property
     def launch_path(self) -> Path:
@@ -49,12 +59,16 @@ class VSCodeEditor(Editor):
 
     def configure(self):
         """Configure VSCode to work with the database."""
-        if not isinstance(self.database, LocalDatabase):
+        if not isinstance(self.database, LocalDatabase) and not self.version:
             return logger.warning(
-                f"No local database associated with repository {self.git.name!r}, skipping VSCode configuration"
+                f"No local database associated with repository {self.git.name!r}, "
+                f"skipping {self.display_name} configuration"
             )
 
-        with progress.spinner(f"Configuring {self._display_name} for project {self.git.name!r}"):
+        if self.workspace_path.is_file():
+            return logger.debug("Workspace file already exists")
+
+        with progress.spinner(f"Configuring {self.display_name} for project {self.git.name!r}"):
             self.workspace_directory.mkdir(parents=True, exist_ok=True)
 
             missing_files = filter(
@@ -63,40 +77,52 @@ class VSCodeEditor(Editor):
             )
 
             if not list(missing_files):
-                return logger.debug("VSCode config files already exist")
+                return logger.debug(f"{self.display_name} config files already exist")
 
-            self._create_workspace()
-            self._create_launch()
-            self._create_tasks()
+            created_files_list = []
 
-            created_files = string.join_bullet(
-                [
-                    f"Workspace: {self.workspace_path}",
+            if self._create_workspace():
+                created_files_list.append(f"Workspace: {self.workspace_path}")
+
+            if not self.version:
+                self._create_launch()
+                self._create_tasks()
+                created_files_list.extend([
                     f"Debugging: {self.launch_path}",
                     f"Tasks: {self.tasks_path}",
-                ],
-            )
-            logger.info(f"Created VSCode config for project {self.git.name!r}\n{created_files}")
+                ])
 
-    def _create_workspace(self):
+            created_files = string.join_bullet(created_files_list)
+            logger.info(f"Created {self.display_name} config for project {self.git.name!r}\n{created_files}")
+
+    def _create_workspace(self) -> bool:
         """Create a workspace file for the project."""
-        assert isinstance(self.database, LocalDatabase)
-
         if self.workspace_path.is_file():
-            return logger.debug("Workspace file already exists")
+            logger.debug("Workspace file already exists")
+            return False
 
         workspace_config = {
-            "folders": [{"path": ".."}],
+            "folders": [],
             "settings": {
                 "terminal.integrated.cwd": self.path.as_posix(),
-                "python.defaultInterpreterPath": self.database.venv.python.as_posix(),
             },
         }
 
-        for worktree in self.database.worktrees:
-            cast(list, workspace_config["folders"]).append({"path": worktree.path.as_posix()})
+        process = (
+            self.database.process
+            if isinstance(self.database, LocalDatabase) and self.database.process
+            else OdoobinProcess(self.database, self.version).with_edition("enterprise")
+        )
+
+        if isinstance(self.database, LocalDatabase):
+            workspace_config["folders"].append({"path": ".."})
+            workspace_config["settings"]["python.defaultInterpreterPath"] = self.database.venv.python.as_posix()
+
+        for worktree in process.odoo_worktrees:
+            workspace_config["folders"].append({"path": worktree.path.as_posix()})
 
         console.print(json.dumps(workspace_config, indent=4), file=self.workspace_path)
+        return True
 
     def _create_launch(self):
         """Create a launch file for the project."""


### PR DESCRIPTION
## Description

Add support for opening a workspace containing only standard modules for a specific Odoo version.

Also add support for other editors sharing the same base as VSCode (i.e.: VSCodium, Antigravity).

## Compliance

- [x] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [x] I have added or modified unit tests where necessary
- [x] I have added new libraries to the `requirements.txt` file, if any
- [x] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**
